### PR TITLE
Fix for onprem auth environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 0.1.1
+
+### Fixed
+
+- Fixed case where onprem use mistakently required ORACLE_NOSQL_AUTH=onprem environment setting.
+
 ## 0.1.0
 
 - First released version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle-nosql-rust-sdk"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.78"
 license = "UPL-1.0"
 description = "Oracle Rust SDK for the NoSQL Database"
@@ -28,7 +28,7 @@ dirs = "5.0.1"
 serde_json = { version = "1.0.128", features = ["arbitrary_precision"] }
 bigdecimal = "0.4.5"
 derive_builder = { version = "0.20.0" }
-oracle-nosql-rust-sdk-derive = { version = "0.1.0" }
+oracle-nosql-rust-sdk-derive = { version = "0.1" }
 async-recursion = "1.1.1"
 openssl =  { version = "0.10.66", features = ["vendored"] }
 base64ct = { version = "1.6.0", features = ["alloc", "std"] }

--- a/oracle-nosql-rust-sdk-derive/Cargo.toml
+++ b/oracle-nosql-rust-sdk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle-nosql-rust-sdk-derive"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.78"
 license = "UPL-1.0"
 description = "Oracle Rust SDK Derives for the NoSQL Database"

--- a/src/handle_builder.rs
+++ b/src/handle_builder.rs
@@ -7,6 +7,7 @@
 //! Builder for creating a [`NoSQL Handle`](crate::Handle)
 //!
 
+
 use base64::prelude::{Engine as _, BASE64_STANDARD};
 use std::default::Default;
 use std::env;
@@ -253,6 +254,8 @@ impl HandleBuilder {
         self.mode = mode;
         if self.mode == HandleMode::Cloudsim {
             self.auth_type = AuthType::Cloudsim;
+        } else if self.mode == HandleMode::Onprem {
+            self.auth_type = AuthType::Onprem;
         }
         Ok(self)
     }
@@ -380,6 +383,7 @@ impl HandleBuilder {
             self.auth = Arc::new(tokio::sync::Mutex::new(AuthConfig { provider: ap }));
         }
         self.mode = HandleMode::Onprem;
+        self.auth_type = AuthType::Onprem;
         Ok(self)
     }
     /// Specify credentials for use with a secure On-premises NoSQL Server from a local file.


### PR DESCRIPTION
The auth code mistakenly require ORACLE_NOSQL_AUTH=onprem even if the application specified
`.mode(HandleMode::Onprem)`. This has been fixed.