### PR TITLE
Preparing for 0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 0.1.3 05/18/2026
+
+### Added
+- Added latest OCI region codes
+
+### Changed
+- Updated copyrights to 2026
+- Enabled QTF tests to run against a cloud instance
+
+### Fixed
+- Fixed compiler warnings, security issues, formatting
+- Fixed prepared queries for 22.4 and lower servers
+- Fixed various QTF tests
+
+
 ## 0.1.2 08/13/2025
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oracle-nosql-rust-sdk"
-version = "0.1.2"
+version = "0.1.3"
 rust-version = "1.78"
 license = "UPL-1.0"
 description = "Oracle Rust SDK for the NoSQL Database"


### PR DESCRIPTION
## 0.1.3 

### Added
- Added latest OCI region codes

### Changed
- Updated copyrights to 2026
- Enabled QTF tests to run against a cloud instance

### Fixed
- Fixed compiler warnings, security issues, formatting
- Fixed prepared queries for 22.4 and lower servers
- Fixed various QTF tests
