### PR TITLE
Fixes for medium-severity issues

### DIFF
--- a/src/auth_common/authentication_provider.rs
+++ b/src/auth_common/authentication_provider.rs
@@ -31,6 +31,11 @@ pub trait AuthenticationProvider: Send + Sync + Debug + AuthenticationProviderCl
     }
     /// Returns the region-id associated with this AuthenticationProvider
     fn region_id(&self) -> &str;
+    /// Returns true if this AuthenticationProvider should be refreshed before
+    /// it is used to sign another request.
+    fn should_refresh(&self) -> bool {
+        false
+    }
 }
 
 // This allows users of this library to clone a Box<dyn AuthenticationProvider>

--- a/src/auth_common/instance_principal_auth_provider.rs
+++ b/src/auth_common/instance_principal_auth_provider.rs
@@ -14,6 +14,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tracing::{debug, instrument, trace};
 use url::Url;
@@ -23,6 +25,8 @@ use crate::auth_common::signer;
 
 static METADATA_URL_BASE: &str = "http://169.254.169.254/opc/v2";
 static EMPTY_STRING: &str = "";
+#[cfg(test)]
+static EXPECTED_NEW_WITH_CLIENT: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Clone)]
 pub struct InstancePrincipalAuthProvider {
@@ -69,14 +73,32 @@ impl AuthenticationProvider for InstancePrincipalAuthProvider {
 }
 
 impl InstancePrincipalAuthProvider {
-    pub async fn new() -> Result<InstancePrincipalAuthProvider, Box<dyn Error>> {
-        InstancePrincipalAuthProvider::new_with_client(&reqwest::Client::builder().build()?).await
+    #[cfg(test)]
+    pub(crate) fn expect_next_new_with_client_for_test(client: &reqwest::Client) {
+        EXPECTED_NEW_WITH_CLIENT.store(client as *const reqwest::Client as usize, Ordering::SeqCst);
     }
 
     #[instrument(skip(client))]
     pub async fn new_with_client(
         client: &reqwest::Client,
     ) -> Result<InstancePrincipalAuthProvider, Box<dyn Error>> {
+        #[cfg(test)]
+        {
+            let expected = EXPECTED_NEW_WITH_CLIENT.swap(0, Ordering::SeqCst);
+            if expected != 0 {
+                let actual = client as *const reqwest::Client as usize;
+                let message = if actual == expected {
+                    "test marker: instance principal used supplied client".to_string()
+                } else {
+                    format!(
+                        "test marker: instance principal used unexpected client {:x}, expected {:x}",
+                        actual, expected
+                    )
+                };
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, message).into());
+            }
+        }
+
         let mut auth_headers: HeaderMap = HeaderMap::new();
         auth_headers.insert("Authorization", "Bearer Oracle".parse()?);
 

--- a/src/auth_common/instance_principal_auth_provider.rs
+++ b/src/auth_common/instance_principal_auth_provider.rs
@@ -198,25 +198,22 @@ async fn get_instance_metadata(
 fn get_tenancy_id_from_certificate(cert: &str) -> Result<String, Box<dyn Error>> {
     let cert = cert.as_bytes();
     let cert = X509::from_pem(cert)?;
-    let mut subject = String::from_utf8_lossy(&cert.to_text()?).into_owned();
 
-    // In text form, the cert contains a Subject line like this:
-    // Subject: CN=ocid1.instance.oc1.eu-zurich-1.an5heljrckmxu5ichjk4nyxrwqg3abrsafgyh4niyl6vs3lmdjfjio3t463a, OU=opc-certtype:instance, OU=opc-compartment:ocid1.tenancy.oc1..aaaaaaaattuxbj75pnn3nksvzyidshdbrfmmeflv4kkemajroz2thvca4kba, OU=opc-instance:ocid1.instance.oc1.eu-zurich-1.an5heljrckmxu5ichjk4nyxrwqg3abrsafgyh4niyl6vs3lmdjfjio3t463a, OU=opc-tenant:ocid1.tenancy.oc1..aaaaaaaattuxbj75pnn3nksvzyidshdbrfmmeflv4kkemajroz2thvca4kba
-    // This code attempts to extract the 'opc-tenant:____________' value
-    // Note the cert also has the compartment ocid as well, which may be useful for users of this library
+    // Instance principal certificates carry the tenancy as an X509 subject value
+    // such as OU=opc-tenant:ocid1.tenancy.oc1...
+    for entry in cert.subject_name().entries() {
+        let value = match entry.data().as_utf8() {
+            Ok(value) => value.to_string(),
+            Err(_) => continue,
+        };
 
-    if let Some(off) = subject.find("=opc-tenant:ocid1.tenancy.") {
-        // 12 == length of "=opc-tenant:"
-        let mut tenancy_id = subject.split_off(off + 12);
-        // strip trailing: start at comma, newline, or space
-        for i in [',', ' ', '\n', '\r'] {
-            if let Some(coff) = tenancy_id.find(i) {
-                let _ = tenancy_id.split_off(coff - 1);
+        if let Some(tenancy_id) = value.strip_prefix("opc-tenant:") {
+            if tenancy_id.starts_with("ocid1.tenancy.") {
+                return Ok(tenancy_id.to_string());
             }
         }
-        //println!("tenancy='{}'", tenancy_id);
-        return Ok(tenancy_id);
     }
+
     return Err("Cannot find tenancy id in certificate".into());
 }
 
@@ -331,6 +328,12 @@ pub fn now_in_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openssl::asn1::{Asn1Integer, Asn1Time};
+    use openssl::bn::BigNum;
+    use openssl::hash::MessageDigest;
+    use openssl::nid::Nid;
+    use openssl::pkey::PKey;
+    use openssl::x509::X509NameBuilder;
 
     #[test]
     fn debug_redacts_token_and_private_key() {
@@ -346,5 +349,53 @@ mod tests {
 
         assert!(!debug.contains("secret-security-token"));
         assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn tenancy_id_from_certificate_preserves_last_character_before_next_subject_entry() {
+        let tenancy_id = "ocid1.tenancy.oc1..abcdefghijklmnopqrstu";
+        let cert = test_certificate_with_subject_entries(&[
+            (Nid::COMMONNAME, "ocid1.instance.oc1.iad.example"),
+            (Nid::ORGANIZATIONALUNITNAME, "opc-certtype:instance"),
+            (
+                Nid::ORGANIZATIONALUNITNAME,
+                &format!("opc-tenant:{tenancy_id}"),
+            ),
+            (
+                Nid::ORGANIZATIONALUNITNAME,
+                "opc-instance:ocid1.instance.oc1.iad.example",
+            ),
+        ]);
+
+        let parsed = get_tenancy_id_from_certificate(&cert).unwrap();
+
+        assert_eq!(parsed, tenancy_id);
+    }
+
+    fn test_certificate_with_subject_entries(entries: &[(Nid, &str)]) -> String {
+        let rsa = Rsa::generate(2048).unwrap();
+        let pkey = PKey::from_rsa(rsa).unwrap();
+
+        let mut name_builder = X509NameBuilder::new().unwrap();
+        for (nid, value) in entries {
+            name_builder.append_entry_by_nid(*nid, value).unwrap();
+        }
+        let subject_name = name_builder.build();
+
+        let mut builder = X509::builder().unwrap();
+        builder.set_version(2).unwrap();
+        let serial_number = BigNum::from_u32(1).unwrap();
+        let serial_number = Asn1Integer::from_bn(&serial_number).unwrap();
+        builder.set_serial_number(&serial_number).unwrap();
+        builder.set_subject_name(&subject_name).unwrap();
+        builder.set_issuer_name(&subject_name).unwrap();
+        builder.set_pubkey(&pkey).unwrap();
+        let not_before = Asn1Time::days_from_now(0).unwrap();
+        let not_after = Asn1Time::days_from_now(1).unwrap();
+        builder.set_not_before(&not_before).unwrap();
+        builder.set_not_after(&not_after).unwrap();
+        builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+
+        String::from_utf8(builder.build().to_pem().unwrap()).unwrap()
     }
 }

--- a/src/auth_common/resource_principal_auth_provider.rs
+++ b/src/auth_common/resource_principal_auth_provider.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use std::env;
 use std::error::Error;
 use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::trace;
 
 use crate::auth_common::authentication_provider::AuthenticationProvider;
@@ -38,13 +39,16 @@ static RP_REGION_ENV: &str = "OCI_RESOURCE_PRINCIPAL_REGION";
 // the key used to look up the resource tenancy in an RPST
 static TENANCY_CLAIM_KEY: &str = "res_tenant";
 
+// Refresh resource principal material shortly before RPST expiry.
+static RP_REFRESH_WINDOW_SECS: u64 = 300;
+
 #[derive(Clone)]
 pub struct ResourcePrincipalAuthProvider {
     token: String,
     session_private_key: Rsa<Private>,
     tenancy_id: String,
     region: String,
-    //expiration: u64, // seconds since the epoch
+    expiration_secs: u64,
 }
 
 impl fmt::Debug for ResourcePrincipalAuthProvider {
@@ -77,6 +81,9 @@ impl AuthenticationProvider for ResourcePrincipalAuthProvider {
     }
     fn key_id(&self) -> String {
         self.token.clone()
+    }
+    fn should_refresh(&self) -> bool {
+        self.expires_within_secs(RP_REFRESH_WINDOW_SECS)
     }
 }
 
@@ -191,22 +198,12 @@ impl ResourcePrincipalAuthProvider {
         // the payload should not be padded
         let decoded = Base64Unpadded::decode_vec(&payload)?;
         let v: Value = serde_json::from_slice(&decoded)?;
-        // TODO: better method for checking these values (not checking for "null")
-        let tenancy = format!("{}", v[TENANCY_CLAIM_KEY]).replace("\"", "");
-        if tenancy == "null" {
-            return Err(
-                format!("RPST token missing '{}' in payload", TENANCY_CLAIM_KEY)
-                    .as_str()
-                    .into(),
-            );
+        let tenancy = token_string_claim(&v, TENANCY_CLAIM_KEY)?;
+        let expiration_secs = token_expiration_claim(&v)?;
+        if expiration_secs <= now_in_secs() {
+            return Err("RPST token is expired".into());
         }
-        let exp = format!("{}", v["exp"]).replace("\"", "");
-        if exp == "null" {
-            return Err(format!("RPST token missing 'exp' in payload")
-                .as_str()
-                .into());
-        }
-        trace!("rpst expiration={}", exp);
+        trace!("rpst expiration={}", expiration_secs);
         trace!("using RPST token: len={}", token.chars().count());
 
         Ok(ResourcePrincipalAuthProvider {
@@ -214,8 +211,46 @@ impl ResourcePrincipalAuthProvider {
             session_private_key: session_private_key,
             tenancy_id: tenancy,
             region: region,
+            expiration_secs,
         })
     }
+
+    fn expires_within_secs(&self, window_secs: u64) -> bool {
+        now_in_secs() >= self.expiration_secs.saturating_sub(window_secs)
+    }
+}
+
+fn token_string_claim(v: &Value, claim: &str) -> Result<String, Box<dyn Error>> {
+    let claim_value = v
+        .get(claim)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("RPST token missing '{}' in payload", claim))?;
+    if claim_value.is_empty() {
+        return Err(format!("RPST token has empty '{}' in payload", claim).into());
+    }
+    Ok(claim_value.to_string())
+}
+
+fn token_expiration_claim(v: &Value) -> Result<u64, Box<dyn Error>> {
+    let exp = v
+        .get("exp")
+        .ok_or_else(|| "RPST token missing 'exp' in payload".to_string())?;
+    match exp {
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| "RPST token 'exp' must be a non-negative integer".into()),
+        Value::String(s) => s
+            .parse::<u64>()
+            .map_err(|_| "RPST token 'exp' must be a non-negative integer".into()),
+        _ => Err("RPST token 'exp' must be a non-negative integer".into()),
+    }
+}
+
+fn now_in_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Reversed UNIX time??")
+        .as_secs()
 }
 
 // By contract for the the content of a resource principal to be considered path, it needs to be
@@ -227,6 +262,7 @@ fn is_path(val: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64ct::{Base64Unpadded, Encoding};
 
     #[test]
     fn debug_redacts_token_and_private_key() {
@@ -235,11 +271,54 @@ mod tests {
             session_private_key: Rsa::generate(2048).unwrap(),
             tenancy_id: "tenancy".to_string(),
             region: "region".to_string(),
+            expiration_secs: now_in_secs() + 3600,
         };
 
         let debug = format!("{:?}", provider);
 
         assert!(!debug.contains("secret-rpst-token"));
         assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn new_from_values_stores_expiration_and_uses_refresh_window() {
+        let expiration_secs = now_in_secs() + 3600;
+        let provider = ResourcePrincipalAuthProvider::new_from_values(
+            test_rpst_token("ocid1.tenancy.oc1..abc", expiration_secs),
+            test_private_key_pem(),
+            None,
+            "us-ashburn-1".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(provider.expiration_secs, expiration_secs);
+        assert!(!provider.should_refresh());
+        assert!(provider.expires_within_secs(4000));
+    }
+
+    #[test]
+    fn new_from_values_rejects_expired_rpst() {
+        let err = ResourcePrincipalAuthProvider::new_from_values(
+            test_rpst_token("ocid1.tenancy.oc1..abc", now_in_secs() - 1),
+            test_private_key_pem(),
+            None,
+            "us-ashburn-1".to_string(),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("expired"));
+    }
+
+    fn test_rpst_token(tenancy_id: &str, expiration_secs: u64) -> String {
+        let header = Base64Unpadded::encode_string(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload = Base64Unpadded::encode_string(
+            format!(r#"{{"res_tenant":"{tenancy_id}","exp":{expiration_secs}}}"#).as_bytes(),
+        );
+        format!("{header}.{payload}.signature")
+    }
+
+    fn test_private_key_pem() -> String {
+        let rsa = Rsa::generate(2048).unwrap();
+        String::from_utf8(rsa.private_key_to_pem().unwrap()).unwrap()
     }
 }

--- a/src/delete_request.rs
+++ b/src/delete_request.rs
@@ -165,7 +165,7 @@ impl DeleteRequest {
         self.serialize_internal(&mut w, false, false, &timeout);
         let mut opts = SendOptions {
             timeout: timeout,
-            retryable: true,
+            retryable: false,
             compartment_id: self.compartment_id.clone(),
             table_name: self.table_name.clone(),
             does_reads: self.does_reads(),
@@ -224,8 +224,8 @@ impl DeleteRequest {
 
         if is_sub_request == false {
             ns.end_payload();
-            ns.end_request();
         }
+        ns.end_request();
     }
 
     pub(crate) fn nson_deserialize(r: &mut Reader) -> Result<DeleteResult, NoSQLError> {

--- a/src/get_indexes_request.rs
+++ b/src/get_indexes_request.rs
@@ -132,14 +132,10 @@ impl GetIndexesRequest {
                     MapWalker::expect_type(walker.r, FieldType::Array)?;
                     let _ = walker.r.read_i32()?; // skip array size in bytes
                     let num_elements = walker.r.read_i32()?;
-                    if num_elements < 0 || (num_elements as usize) > walker.r.buf.len() {
-                        return Err(NoSQLError::new(
-                            BadProtocolMessage,
-                            "invalid num_elements in index array",
-                        ));
-                    }
-                    res.indexes = Vec::with_capacity(num_elements as usize);
-                    for _n in 1..=num_elements {
+                    let num_elements = walker.r.checked_count(num_elements, "index array")?;
+                    res.indexes = Vec::new();
+                    Reader::try_reserve_vec(&mut res.indexes, num_elements, "index array")?;
+                    for _n in 0..num_elements {
                         res.indexes
                             .push(GetIndexesRequest::read_index_info(walker.r)?);
                     }
@@ -169,15 +165,12 @@ impl GetIndexesRequest {
                     MapWalker::expect_type(walker.r, FieldType::Array)?;
                     let _ = walker.r.read_i32()?; // skip array size in bytes
                     let num_elements = walker.r.read_i32()?;
-                    if num_elements < 0 || (num_elements as usize) > walker.r.buf.len() {
-                        return Err(NoSQLError::new(
-                            BadProtocolMessage,
-                            "invalid num_elements in fields array",
-                        ));
-                    }
-                    res.field_names = Vec::with_capacity(num_elements as usize);
-                    res.field_types = Vec::with_capacity(num_elements as usize);
-                    for _n in 1..=num_elements {
+                    let num_elements = walker.r.checked_count(num_elements, "fields array")?;
+                    res.field_names = Vec::new();
+                    res.field_types = Vec::new();
+                    Reader::try_reserve_vec(&mut res.field_names, num_elements, "fields array")?;
+                    Reader::try_reserve_vec(&mut res.field_types, num_elements, "fields array")?;
+                    for _n in 0..num_elements {
                         GetIndexesRequest::read_index_fields(walker.r, &mut res)?;
                     }
                 }

--- a/src/get_indexes_request.rs
+++ b/src/get_indexes_request.rs
@@ -92,6 +92,7 @@ impl GetIndexesRequest {
             timeout: timeout,
             retryable: true,
             compartment_id: self.compartment_id.clone(),
+            namespace: self.namespace.clone(),
             ..Default::default()
         };
         let mut r = h.send_and_receive(w, &mut opts).await?;
@@ -108,9 +109,9 @@ impl GetIndexesRequest {
         // payload
         ns.start_payload();
         ns.write_string_field(INDEX, &self.index_name);
+        ns.write_nonempty_string_field(NAMESPACE, &self.namespace);
         // TODO: these are currently only in http headers. Add to NSON?
         //ns.write_string_field(COMPARTMENT_OCID, &self.compartment_id);
-        //ns.write_string_field(NAMESPACE, &self.namespace);
         ns.end_payload();
 
         ns.end_request();

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -380,21 +380,26 @@ impl Handle {
         data: &Vec<u8>,
         send_options: &mut SendOptions,
     ) -> Result<Vec<u8>, NoSQLError> {
+        self.inner.builder.refresh_auth_if_needed().await?;
+
         let request_id = self.inner.request_id.fetch_add(1, Ordering::Relaxed);
         let mut headers = HeaderMap::new();
         headers.insert("x-nosql-request-id", HeaderValue::from(request_id));
 
         // If there is an oci auth provider, use that to set up required headers
         let mut oci_provider: Option<&Box<dyn AuthenticationProvider>> = None;
+        let mut requires_explicit_compartment = false;
 
         // We need to lock the auth config because it may be asynchronously refreshed elsewhere
         let pguard = self.inner.builder.auth.lock().await;
         match &pguard.provider {
             AuthProvider::Instance { provider } => {
                 oci_provider = Some(provider);
+                requires_explicit_compartment = true;
             }
             AuthProvider::Resource { provider } => {
                 oci_provider = Some(provider);
+                requires_explicit_compartment = true;
             }
             AuthProvider::External { provider } => {
                 oci_provider = Some(provider);
@@ -412,17 +417,16 @@ impl Handle {
         }
 
         if let Some(sp) = oci_provider {
-            if !self.inner.builder.default_compartment_id.is_empty() {
-                headers.insert(
-                    "x-nosql-compartment-id",
-                    HeaderValue::from_str(&self.inner.builder.default_compartment_id)?,
-                );
-            } else {
-                headers.insert(
-                    "x-nosql-compartment-id",
-                    HeaderValue::from_str(sp.tenancy_id())?,
-                );
-            }
+            let compartment_id = Self::effective_compartment_id(
+                send_options,
+                &self.inner.builder.default_compartment_id,
+                sp.tenancy_id(),
+                requires_explicit_compartment,
+            )?;
+            headers.insert(
+                "x-nosql-compartment-id",
+                HeaderValue::from_str(&compartment_id)?,
+            );
             {
                 // If there's a session cookie value, set it into the headers.
                 // The lock is needed because another async operation might try to
@@ -451,14 +455,6 @@ impl Handle {
         }
         // this will unlock the auth mutex
         core::mem::drop(pguard);
-
-        // let send_options.compartment_id override compartment header
-        if !send_options.compartment_id.is_empty() {
-            headers.insert(
-                "x-nosql-compartment-id",
-                HeaderValue::from_str(&send_options.compartment_id)?,
-            );
-        }
 
         // let send_options.namespace override namespace header
         if !send_options.namespace.is_empty() {
@@ -634,6 +630,26 @@ impl Handle {
             && (err.code == NoSQLErrorCode::SecurityInfoUnavailable
                 || err.code == NoSQLErrorCode::RetryAuthentication
                 || err.code == NoSQLErrorCode::InvalidAuthorization)
+    }
+
+    fn effective_compartment_id(
+        send_options: &SendOptions,
+        default_compartment_id: &str,
+        tenancy_id: &str,
+        requires_explicit_compartment: bool,
+    ) -> Result<String, NoSQLError> {
+        if !send_options.compartment_id.is_empty() {
+            return Ok(send_options.compartment_id.clone());
+        }
+        if !default_compartment_id.is_empty() {
+            return Ok(default_compartment_id.to_string());
+        }
+        if requires_explicit_compartment {
+            return ia_err!(
+                "instance principal and resource principal authentication require an explicit compartment id"
+            );
+        }
+        Ok(tenancy_id.to_string())
     }
 
     async fn apply_rate_limiting(&self, send_options: &mut SendOptions) -> Result<(), NoSQLError> {
@@ -1057,5 +1073,52 @@ mod tests {
             },
             &siu
         ));
+    }
+
+    #[test]
+    fn effective_compartment_requires_explicit_value_for_instance_and_resource_principals() {
+        let err = Handle::effective_compartment_id(
+            &SendOptions::default(),
+            "",
+            "ocid1.tenancy.oc1..root",
+            true,
+        )
+        .unwrap_err();
+
+        assert!(err.message.contains("explicit compartment id"));
+
+        let request_compartment = Handle::effective_compartment_id(
+            &SendOptions {
+                compartment_id: "ocid1.compartment.oc1..request".to_string(),
+                ..Default::default()
+            },
+            "",
+            "ocid1.tenancy.oc1..root",
+            true,
+        )
+        .unwrap();
+        assert_eq!(request_compartment, "ocid1.compartment.oc1..request");
+
+        let default_compartment = Handle::effective_compartment_id(
+            &SendOptions::default(),
+            "ocid1.compartment.oc1..default",
+            "ocid1.tenancy.oc1..root",
+            true,
+        )
+        .unwrap();
+        assert_eq!(default_compartment, "ocid1.compartment.oc1..default");
+    }
+
+    #[test]
+    fn effective_compartment_keeps_tenancy_fallback_for_user_principals() {
+        let compartment = Handle::effective_compartment_id(
+            &SendOptions::default(),
+            "",
+            "ocid1.tenancy.oc1..root",
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(compartment, "ocid1.tenancy.oc1..root");
     }
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -39,6 +39,7 @@ const RATE_LIMITER_DURATION_SECS: f64 = 30.0;
 const RATE_LIMITER_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
 const RATE_LIMITER_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 const RATE_LIMITER_METADATA_TIMEOUT: Duration = Duration::from_secs(1);
+const SIU_NOT_AUTHENTICATED_MESSAGE: &str = "NotAuthenticated. ";
 
 /// **The main database handle**.
 ///
@@ -587,22 +588,15 @@ impl Handle {
         // allow for up to 4 retries, in case the routing to the service is doing round-robin
         // across instances (typically 3 in NoSQL cloud).
         // TODO: check current nano versus timeout at start of request
-        if send_options.retries < 40 && err.code == NoSQLErrorCode::SecurityInfoUnavailable {
-            // Note space at end of this message
-            if err.message == "NotAuthenticated. " {
-                // TODO: check remaining time for request based on timeout
-                tokio::time::sleep(Duration::from_millis(30)).await;
-                trace!("waited 30ms, now retrying SIU error");
-                return Err(NoSQLError::new(InternalRetry, ""));
-            }
+        if Self::should_retry_not_authenticated(send_options, &err) {
+            // TODO: check remaining time for request based on timeout
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            trace!("waited 30ms, now retrying SIU error");
+            return Err(NoSQLError::new(InternalRetry, ""));
         }
         // For other auth errors, try refreshing the auth provider. It may have
         // expired credentials.
-        if send_options.retries < 4
-            && (err.code == NoSQLErrorCode::SecurityInfoUnavailable
-                || err.code == NoSQLErrorCode::RetryAuthentication
-                || err.code == NoSQLErrorCode::InvalidAuthorization)
-        {
+        if Self::should_refresh_auth_for_retry(send_options, &err) {
             let refreshed = self
                 .inner
                 .builder
@@ -625,6 +619,21 @@ impl Handle {
             trace!("attempt to refresh generated no error but did not refresh auth");
         }
         Err(err)
+    }
+
+    fn should_retry_not_authenticated(send_options: &SendOptions, err: &NoSQLError) -> bool {
+        send_options.retryable
+            && send_options.retries < 40
+            && err.code == NoSQLErrorCode::SecurityInfoUnavailable
+            && err.message == SIU_NOT_AUTHENTICATED_MESSAGE
+    }
+
+    fn should_refresh_auth_for_retry(send_options: &SendOptions, err: &NoSQLError) -> bool {
+        send_options.retryable
+            && send_options.retries < 4
+            && (err.code == NoSQLErrorCode::SecurityInfoUnavailable
+                || err.code == NoSQLErrorCode::RetryAuthentication
+                || err.code == NoSQLErrorCode::InvalidAuthorization)
     }
 
     async fn apply_rate_limiting(&self, send_options: &mut SendOptions) -> Result<(), NoSQLError> {
@@ -979,5 +988,74 @@ mod tests {
 
         assert!(!debug.contains("secret-session-cookie"));
         assert!(debug.contains("[redacted]"));
+    }
+
+    #[test]
+    fn internal_auth_retries_respect_send_options_retryable() {
+        let err = NoSQLError::new(
+            NoSQLErrorCode::SecurityInfoUnavailable,
+            SIU_NOT_AUTHENTICATED_MESSAGE,
+        );
+        let non_retryable = SendOptions {
+            retryable: false,
+            ..Default::default()
+        };
+
+        assert!(!Handle::should_retry_not_authenticated(
+            &non_retryable,
+            &err
+        ));
+        assert!(!Handle::should_refresh_auth_for_retry(&non_retryable, &err));
+
+        let retryable = SendOptions {
+            retryable: true,
+            ..Default::default()
+        };
+
+        assert!(Handle::should_retry_not_authenticated(&retryable, &err));
+        assert!(Handle::should_refresh_auth_for_retry(&retryable, &err));
+    }
+
+    #[test]
+    fn internal_auth_retry_limits_are_enforced() {
+        let err = NoSQLError::new(NoSQLErrorCode::InvalidAuthorization, "expired");
+
+        assert!(Handle::should_refresh_auth_for_retry(
+            &SendOptions {
+                retryable: true,
+                retries: 3,
+                ..Default::default()
+            },
+            &err
+        ));
+        assert!(!Handle::should_refresh_auth_for_retry(
+            &SendOptions {
+                retryable: true,
+                retries: 4,
+                ..Default::default()
+            },
+            &err
+        ));
+
+        let siu = NoSQLError::new(
+            NoSQLErrorCode::SecurityInfoUnavailable,
+            SIU_NOT_AUTHENTICATED_MESSAGE,
+        );
+        assert!(Handle::should_retry_not_authenticated(
+            &SendOptions {
+                retryable: true,
+                retries: 39,
+                ..Default::default()
+            },
+            &siu
+        ));
+        assert!(!Handle::should_retry_not_authenticated(
+            &SendOptions {
+                retryable: true,
+                retries: 40,
+                ..Default::default()
+            },
+            &siu
+        ));
     }
 }

--- a/src/handle_builder.rs
+++ b/src/handle_builder.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::auth_common::authentication_provider::AuthenticationProvider;
 use crate::auth_common::config_file_authentication_provider::ConfigFileAuthenticationProvider;
 use crate::auth_common::instance_principal_auth_provider::InstancePrincipalAuthProvider;
+use crate::auth_common::resource_principal_auth_provider::ResourcePrincipalAuthProvider;
 use crate::error::{ia_err, NoSQLError};
 use crate::handle::Handle;
 use reqwest::header::HeaderValue;
@@ -436,7 +437,9 @@ impl HandleBuilder {
     ///
     /// This value may be overridden on a per-request basis.
     ///
-    /// If no compartment is given, the root compartment of the tenancy will be used.
+    /// If no compartment is given, user-based OCI authentication uses the root compartment of the tenancy.
+    /// Instance-principal and resource-principal authentication require either this default compartment
+    /// or a per-request compartment id.
     pub fn compartment_id(mut self, compartment_id: &str) -> Result<Self, NoSQLError> {
         self.default_compartment_id = compartment_id.to_string();
         Ok(self)
@@ -606,6 +609,13 @@ impl HandleBuilder {
                 };
                 return Ok(true);
             }
+            AuthProvider::Resource { provider: _ } => {
+                let rfp = ResourcePrincipalAuthProvider::new()?;
+                pguard.provider = AuthProvider::Resource {
+                    provider: Box::new(rfp),
+                };
+                return Ok(true);
+            }
             AuthProvider::Onprem { provider } => {
                 if let Some(prov) = provider {
                     let _ = prov.generate_token(client, true).await?;
@@ -615,6 +625,20 @@ impl HandleBuilder {
             _ => {}
         }
         Ok(false)
+    }
+
+    pub(crate) async fn refresh_auth_if_needed(&self) -> Result<bool, NoSQLError> {
+        let mut pguard = self.auth.lock().await;
+        match &mut pguard.provider {
+            AuthProvider::Resource { provider } if provider.should_refresh() => {
+                let rfp = ResourcePrincipalAuthProvider::new()?;
+                pguard.provider = AuthProvider::Resource {
+                    provider: Box::new(rfp),
+                };
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 }
 
@@ -746,6 +770,9 @@ impl OnpremAuthProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64ct::{Base64Unpadded, Encoding};
+    use openssl::rsa::Rsa;
+    use std::env;
 
     #[derive(Clone, Debug)]
     struct TestAuthProvider;
@@ -771,6 +798,108 @@ mod tests {
 
         fn region_id(&self) -> &str {
             "region"
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ExpiringTestAuthProvider;
+
+    impl AuthenticationProvider for ExpiringTestAuthProvider {
+        fn tenancy_id(&self) -> &str {
+            "tenancy"
+        }
+
+        fn fingerprint(&self) -> &str {
+            "fingerprint"
+        }
+
+        fn user_id(&self) -> &str {
+            "user"
+        }
+
+        fn private_key(
+            &self,
+        ) -> Result<openssl::rsa::Rsa<openssl::pkey::Private>, Box<dyn std::error::Error>> {
+            Ok(openssl::rsa::Rsa::generate(2048)?)
+        }
+
+        fn region_id(&self) -> &str {
+            "region"
+        }
+
+        fn should_refresh(&self) -> bool {
+            true
+        }
+    }
+
+    static RESOURCE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct ResourcePrincipalEnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl Drop for ResourcePrincipalEnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn set_resource_principal_env(tenancy_id: &str) -> ResourcePrincipalEnvGuard {
+        let lock = RESOURCE_ENV_LOCK.lock().unwrap();
+        let keys = [
+            "OCI_RESOURCE_PRINCIPAL_VERSION",
+            "OCI_RESOURCE_PRINCIPAL_RPST",
+            "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM",
+            "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM_PASSPHRASE",
+            "OCI_RESOURCE_PRINCIPAL_REGION",
+        ];
+        let saved = keys.iter().map(|key| (*key, env::var(key).ok())).collect();
+
+        env::set_var("OCI_RESOURCE_PRINCIPAL_VERSION", "2.2");
+        env::set_var(
+            "OCI_RESOURCE_PRINCIPAL_RPST",
+            test_rpst_token(tenancy_id, now_secs() + 3600),
+        );
+        env::set_var("OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM", test_private_key_pem());
+        env::remove_var("OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM_PASSPHRASE");
+        env::set_var("OCI_RESOURCE_PRINCIPAL_REGION", "us-ashburn-1");
+
+        ResourcePrincipalEnvGuard { _lock: lock, saved }
+    }
+
+    fn test_rpst_token(tenancy_id: &str, expiration_secs: u64) -> String {
+        let header = Base64Unpadded::encode_string(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload = Base64Unpadded::encode_string(
+            format!(r#"{{"res_tenant":"{tenancy_id}","exp":{expiration_secs}}}"#).as_bytes(),
+        );
+        format!("{header}.{payload}.signature")
+    }
+
+    fn test_private_key_pem() -> String {
+        let rsa = Rsa::generate(2048).unwrap();
+        String::from_utf8(rsa.private_key_to_pem().unwrap()).unwrap()
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    async fn assert_resource_provider_tenancy(builder: &HandleBuilder, tenancy_id: &str) {
+        let guard = builder.auth.lock().await;
+        match &guard.provider {
+            AuthProvider::Resource { provider } => {
+                assert_eq!(provider.tenancy_id(), tenancy_id);
+            }
+            provider => panic!("expected resource provider, got {:?}", provider),
         }
     }
 
@@ -822,6 +951,43 @@ mod tests {
         assert!(!auth_debug.contains("secret-password"));
         assert!(builder_debug.contains("[redacted]"));
         assert!(auth_debug.contains("[redacted]"));
+    }
+
+    #[tokio::test]
+    async fn resource_principal_refresh_reloads_env_material_after_auth_error() {
+        let tenancy_id = "ocid1.tenancy.oc1..refreshed";
+        let _env_guard = set_resource_principal_env(tenancy_id);
+        let client = Client::builder().build().unwrap();
+        let mut builder = HandleBuilder::new();
+        builder.auth_type = AuthType::Resource;
+        builder.auth = Arc::new(tokio::sync::Mutex::new(AuthConfig {
+            provider: AuthProvider::Resource {
+                provider: Box::new(TestAuthProvider),
+            },
+        }));
+
+        let refreshed = builder.refresh_auth(&client).await.unwrap();
+
+        assert!(refreshed);
+        assert_resource_provider_tenancy(&builder, tenancy_id).await;
+    }
+
+    #[tokio::test]
+    async fn resource_principal_refresh_if_needed_reloads_expiring_provider() {
+        let tenancy_id = "ocid1.tenancy.oc1..preemptive";
+        let _env_guard = set_resource_principal_env(tenancy_id);
+        let mut builder = HandleBuilder::new();
+        builder.auth_type = AuthType::Resource;
+        builder.auth = Arc::new(tokio::sync::Mutex::new(AuthConfig {
+            provider: AuthProvider::Resource {
+                provider: Box::new(ExpiringTestAuthProvider),
+            },
+        }));
+
+        let refreshed = builder.refresh_auth_if_needed().await.unwrap();
+
+        assert!(refreshed);
+        assert_resource_provider_tenancy(&builder, tenancy_id).await;
     }
 
     #[tokio::test]

--- a/src/handle_builder.rs
+++ b/src/handle_builder.rs
@@ -600,7 +600,7 @@ impl HandleBuilder {
         match &mut pguard.provider {
             AuthProvider::Instance { provider: _ } => {
                 // create an entirely new IP auth, as currently IP Auth has no methods to refresh itself
-                let ifp = InstancePrincipalAuthProvider::new().await?;
+                let ifp = InstancePrincipalAuthProvider::new_with_client(client).await?;
                 pguard.provider = AuthProvider::Instance {
                     provider: Box::new(ifp),
                 };
@@ -747,6 +747,33 @@ impl OnpremAuthProvider {
 mod tests {
     use super::*;
 
+    #[derive(Clone, Debug)]
+    struct TestAuthProvider;
+
+    impl AuthenticationProvider for TestAuthProvider {
+        fn tenancy_id(&self) -> &str {
+            "tenancy"
+        }
+
+        fn fingerprint(&self) -> &str {
+            "fingerprint"
+        }
+
+        fn user_id(&self) -> &str {
+            "user"
+        }
+
+        fn private_key(
+            &self,
+        ) -> Result<openssl::rsa::Rsa<openssl::pkey::Private>, Box<dyn std::error::Error>> {
+            Ok(openssl::rsa::Rsa::generate(2048)?)
+        }
+
+        fn region_id(&self) -> &str {
+            "region"
+        }
+    }
+
     #[test]
     fn onprem_debug_redacts_credentials_and_token() {
         let auth_ref = OnpremAuthProviderRef {
@@ -795,5 +822,27 @@ mod tests {
         assert!(!auth_debug.contains("secret-password"));
         assert!(builder_debug.contains("[redacted]"));
         assert!(auth_debug.contains("[redacted]"));
+    }
+
+    #[tokio::test]
+    async fn instance_principal_refresh_uses_supplied_client() {
+        let client = Client::builder().build().unwrap();
+        InstancePrincipalAuthProvider::expect_next_new_with_client_for_test(&client);
+        let mut builder = HandleBuilder::new();
+        builder.auth_type = AuthType::Instance;
+        builder.auth = Arc::new(tokio::sync::Mutex::new(AuthConfig {
+            provider: AuthProvider::Instance {
+                provider: Box::new(TestAuthProvider),
+            },
+        }));
+
+        let err = builder.refresh_auth(&client).await.unwrap_err();
+
+        assert!(
+            err.message
+                .contains("test marker: instance principal used supplied client"),
+            "{}",
+            err
+        );
     }
 }

--- a/src/list_tables_request.rs
+++ b/src/list_tables_request.rs
@@ -86,6 +86,7 @@ impl ListTablesRequest {
             timeout: timeout,
             retryable: true,
             compartment_id: self.compartment_id.clone(),
+            namespace: self.namespace.clone(),
             ..Default::default()
         };
         let mut r = h.send_and_receive(w, &mut opts).await?;

--- a/src/nson.rs
+++ b/src/nson.rs
@@ -414,12 +414,13 @@ impl<'a> MapWalker<'a> {
         Self::expect_type(r, FieldType::Map)?;
         let _ = r.read_i32()?; // skip map size in bytes
         let num_elements = r.read_i32()?;
-        if num_elements < 0 || num_elements > MAX_ELEMENTS {
+        if num_elements > MAX_ELEMENTS {
             return Err(NoSQLError::new(
                 BadProtocolMessage,
                 "invalid num_elements in message",
             ));
         }
+        let num_elements = r.checked_count(num_elements, "map message")? as i32;
         //println!("MapWalker: num_elements={}", num_elements);
         Ok(MapWalker {
             r,
@@ -493,14 +494,10 @@ impl<'a> MapWalker<'a> {
         Self::expect_type(self.r, FieldType::Array)?;
         let _ = self.r.read_i32()?; // skip array size in bytes
         let num_elements = self.r.read_i32()?;
-        if num_elements < 0 || (num_elements as usize) > self.r.buf.len() {
-            return Err(NoSQLError::new(
-                BadProtocolMessage,
-                "invalid num_elements in string array",
-            ));
-        }
-        let mut v: Vec<String> = Vec::with_capacity(num_elements as usize);
-        for _n in 1..=num_elements {
+        let num_elements = self.r.checked_count(num_elements, "string array")?;
+        let mut v: Vec<String> = Vec::new();
+        Reader::try_reserve_vec(&mut v, num_elements, "string array")?;
+        for _n in 0..num_elements {
             v.push(self.read_nson_string()?);
         }
         //println!("read_nson_string_array={:?}", v);
@@ -511,14 +508,10 @@ impl<'a> MapWalker<'a> {
         Self::expect_type(self.r, FieldType::Array)?;
         let _ = self.r.read_i32()?; // skip array size in bytes
         let num_elements = self.r.read_i32()?;
-        if num_elements < 0 || (num_elements as usize) > self.r.buf.len() {
-            return Err(NoSQLError::new(
-                BadProtocolMessage,
-                "invalid num_elements in i32 array",
-            ));
-        }
-        let mut v: Vec<i32> = Vec::with_capacity(num_elements as usize);
-        for _n in 1..=num_elements {
+        let num_elements = self.r.checked_count(num_elements, "i32 array")?;
+        let mut v: Vec<i32> = Vec::new();
+        Reader::try_reserve_vec(&mut v, num_elements, "i32 array")?;
+        for _n in 0..num_elements {
             v.push(self.read_nson_i32()?);
         }
         //println!("read_nson_i32_array={:?}", v);

--- a/src/packed_integer.rs
+++ b/src/packed_integer.rs
@@ -240,16 +240,19 @@ pub fn write_packed_i64(v: &mut Vec<u8>, val: i64) {
     v.push((i + 127) as u8);
 }
 
-// check that the offset will not run off the end of the vector, then
-// increment it.
-fn increment_and_check(offset: &mut usize, len: usize) -> Result<(), NoSQLError> {
-    if *offset >= len {
+fn validate_packed_len(
+    buf_len: usize,
+    offset: usize,
+    value_len: usize,
+    max_len: usize,
+    type_name: &str,
+) -> Result<(), NoSQLError> {
+    if value_len > max_len || buf_len.saturating_sub(offset) < value_len {
         return Err(NoSQLError::new(
             BadProtocolMessage,
-            "attempt to read past end of buffer",
+            format!("invalid {} in buffer", type_name).as_str(),
         ));
     }
-    *offset += 1;
     Ok(())
 }
 
@@ -263,7 +266,7 @@ pub fn read_packed_i32(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i32, NoS
     }
     // The first byte stores the length of the value part.
     let mut len: u8 = buf[*offset];
-    increment_and_check(offset, buf.len())?;
+    *offset += 1;
 
     let mut is_negative: bool = false;
 
@@ -277,6 +280,9 @@ pub fn read_packed_i32(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i32, NoS
         return Ok((len as i32) - 127);
     }
 
+    let value_len = len as usize;
+    validate_packed_len(buf.len(), *offset, value_len, 4, "packed_i32")?;
+
     // The following bytes on the buf store the value as a big endian integer.
     // We extract the significant bytes from the buf and put them into the
     // value in big endian order.
@@ -285,13 +291,10 @@ pub fn read_packed_i32(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i32, NoS
         value = -1; // 0xFFFFFFFF
     }
 
-    while len > 1 {
+    for _ in 0..value_len {
         value = (value << 8) | (buf[*offset] as i32);
-        increment_and_check(offset, buf.len())?;
-        len -= 1;
+        *offset += 1;
     }
-    value = (value << 8) | (buf[*offset] as i32);
-    increment_and_check(offset, buf.len())?;
 
     // After get the adjusted value, we have to adjust it back to the
     // original value.
@@ -313,7 +316,7 @@ pub fn read_packed_i64(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i64, NoS
     }
     // The first byte stores the length of the value part.
     let mut len: u8 = buf[*offset];
-    increment_and_check(offset, buf.len())?;
+    *offset += 1;
 
     let mut is_negative: bool = false;
 
@@ -327,6 +330,9 @@ pub fn read_packed_i64(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i64, NoS
         return Ok((len as i64) - 127);
     }
 
+    let value_len = len as usize;
+    validate_packed_len(buf.len(), *offset, value_len, 8, "packed_i64")?;
+
     // The following bytes on the buf store the value as a big endian integer.
     // We extract the significant bytes from the buf and put them into the
     // value in big endian order.
@@ -335,13 +341,10 @@ pub fn read_packed_i64(buf: &mut Vec<u8>, offset: &mut usize) -> Result<i64, NoS
         value = -1; // 0xFFFFFFFFFFFFFFFF
     }
 
-    while len > 1 {
+    for _ in 0..value_len {
         value = (value << 8) | (buf[*offset] as i64);
-        increment_and_check(offset, buf.len())?;
-        len -= 1;
+        *offset += 1;
     }
-    value = (value << 8) | (buf[*offset] as i64);
-    increment_and_check(offset, buf.len())?;
 
     // After get the adjusted value, we have to adjust it back to the
     // original value.

--- a/src/plan_iter.rs
+++ b/src/plan_iter.rs
@@ -487,7 +487,9 @@ pub(crate) fn deserialize_plan_iters(r: &mut Reader) -> Result<Vec<Box<PlanIter>
         return Ok(Vec::new());
     }
 
-    let mut iters: Vec<Box<PlanIter>> = Vec::with_capacity(n as usize);
+    let n = r.checked_count(n, "plan iterator sequence")?;
+    let mut iters: Vec<Box<PlanIter>> = Vec::new();
+    Reader::try_reserve_vec(&mut iters, n, "plan iterator sequence")?;
     for _i in 0..n {
         let iter = deserialize_plan_iter(r)?;
         if iter.get_kind() != PlanIterKind::Empty {

--- a/src/query_request.rs
+++ b/src/query_request.rs
@@ -6,6 +6,7 @@
 //
 use crate::error::ia_err;
 use crate::error::NoSQLError;
+use crate::error::NoSQLErrorCode;
 use crate::handle::Handle;
 use crate::handle::SendOptions;
 use crate::nson::*;
@@ -817,9 +818,11 @@ impl QueryRequest {
         walker.r.read_i32()?; // length of array in bytes
         let num_elements = walker.r.read_i32()?;
         trace!("read_results: num_results={}", num_elements);
-        if num_elements <= 0 {
+        let num_elements = walker.r.checked_count(num_elements, "query results")?;
+        if num_elements == 0 {
             return Ok(());
         }
+        Reader::try_reserve_vec(results, num_elements, "query results")?;
         for _i in 0..num_elements {
             if let FieldValue::Map(m) = walker.r.read_field_value()? {
                 //println!("Result: {:?}", m);
@@ -1037,21 +1040,32 @@ impl QueryRequest {
         if self.prepared_statement.driver_query_plan.get_kind() == PlanIterKind::Empty {
             return Ok(());
         }
-        self.prepared_statement.num_iterators = r.read_i32()?;
+        let num_iterators = r.read_i32()?;
+        Reader::checked_count_with_limit(num_iterators, v.len(), "driver plan iterators")?;
+        self.prepared_statement.num_iterators = num_iterators;
         //println!(
         //"   QUERY_PLAN: iterators={}",
         //self.prepared_statement.num_iterators
         //);
-        self.prepared_statement.num_registers = r.read_i32()?;
+        let num_registers = r.read_i32()?;
+        Reader::checked_count_with_limit(num_registers, v.len(), "driver plan registers")?;
+        self.prepared_statement.num_registers = num_registers;
         //println!(
         //"   QUERY_PLAN: registers={}",
         //self.prepared_statement.num_registers
         //);
         let len = r.read_i32()?;
-        if len <= 0 {
+        let len = r.checked_count(len, "driver plan variables")?;
+        if len == 0 {
             return Ok(());
         }
-        let mut hm: HashMap<String, i32> = HashMap::with_capacity(len as usize);
+        let mut hm: HashMap<String, i32> = HashMap::new();
+        hm.try_reserve(len).map_err(|_| {
+            NoSQLError::new(
+                NoSQLErrorCode::BadProtocolMessage,
+                "unable to reserve decoded values for driver plan variables",
+            )
+        })?;
         for _i in 0..len {
             let name = r.read_string()?;
             let id = r.read_i32()?;
@@ -1080,30 +1094,34 @@ impl QueryRequest {
     }
 
     pub(crate) fn get_result(&mut self, reg: i32) -> FieldValue {
-        if self.num_registers <= reg {
-            panic!("INVALID GET REGISTER ACCESS");
-        }
+        let reg = self.register_index(reg, "GET");
         //println!(
         //" get_result register {}: {:?}",
         //reg, self.registers[reg as usize]
         //);
-        std::mem::take(&mut self.registers[reg as usize])
+        std::mem::take(&mut self.registers[reg])
     }
 
     pub(crate) fn get_result_ref(&self, reg: i32) -> &FieldValue {
+        let reg = self.register_index(reg, "GET");
         //println!(
         //" get_result_ref register {}: {:?}",
         //reg, self.registers[reg as usize]
         //);
-        &self.registers[reg as usize]
+        &self.registers[reg]
     }
 
     pub(crate) fn set_result(&mut self, reg: i32, val: FieldValue) {
-        if self.num_registers <= reg {
-            panic!("INVALID SET REGISTER ACCESS");
-        }
+        let reg = self.register_index(reg, "SET");
         //println!(" set_result register {}: {:?}", reg, val);
-        self.registers[reg as usize] = val;
+        self.registers[reg] = val;
+    }
+
+    fn register_index(&self, reg: i32, op: &str) -> usize {
+        if reg < 0 || self.num_registers <= reg {
+            panic!("INVALID {} REGISTER ACCESS", op);
+        }
+        reg as usize
     }
 }
 
@@ -1148,5 +1166,15 @@ mod tests {
         let mut prepared_mutation = prepared_select.clone();
         prepared_mutation.operation = 0;
         assert!(!QueryRequest::new_prepared(&prepared_mutation).is_retryable());
+    }
+
+    #[test]
+    #[should_panic(expected = "INVALID GET REGISTER ACCESS")]
+    fn negative_query_register_is_rejected_before_indexing() {
+        let mut request = QueryRequest::default();
+        request.num_registers = 1;
+        request.registers.push(FieldValue::Uninitialized);
+
+        let _ = request.get_result(-1);
     }
 }

--- a/src/query_request.rs
+++ b/src/query_request.rs
@@ -24,6 +24,62 @@ use tracing::trace;
 
 const DRIVER_QUERY_VERSION: i32 = 6;
 
+fn is_retryable_query_statement(statement: &str) -> bool {
+    matches!(
+        first_sql_operation_keyword(statement).as_deref(),
+        Some("select")
+    )
+}
+
+fn first_sql_operation_keyword(statement: &str) -> Option<String> {
+    let (keyword, mut remaining) = split_leading_sql_keyword(statement)?;
+    let keyword = keyword.to_ascii_lowercase();
+    if keyword != "declare" {
+        return Some(keyword);
+    }
+
+    loop {
+        let declaration_end = remaining.find(';')?;
+        remaining = trim_sql_leading_noise(&remaining[declaration_end + 1..]);
+        if remaining.starts_with('$') {
+            continue;
+        }
+        return first_sql_operation_keyword(remaining);
+    }
+}
+
+fn split_leading_sql_keyword(statement: &str) -> Option<(&str, &str)> {
+    let statement = trim_sql_leading_noise(statement);
+    let end = statement
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(statement.len());
+    if end == 0 {
+        return None;
+    }
+    Some((&statement[..end], &statement[end..]))
+}
+
+fn trim_sql_leading_noise(mut statement: &str) -> &str {
+    loop {
+        let trimmed = statement.trim_start();
+        if let Some(comment) = trimmed.strip_prefix("--") {
+            if let Some(end) = comment.find('\n') {
+                statement = &comment[end + 1..];
+                continue;
+            }
+            return "";
+        }
+        if let Some(comment) = trimmed.strip_prefix("/*") {
+            if let Some(end) = comment.find("*/") {
+                statement = &comment[end + 2..];
+                continue;
+            }
+            return "";
+        }
+        return trimmed;
+    }
+}
+
 /// Encapsulates a SQL query of a NoSQL Database table.
 ///
 /// A query may be either a string query
@@ -311,6 +367,19 @@ impl QueryRequest {
 
     fn does_writes_for_rate_limiting(&self) -> bool {
         self.prepared_statement.does_writes()
+    }
+
+    fn is_retryable(&self) -> bool {
+        if self.prepare_only {
+            return true;
+        }
+        if !self.prepared_statement.is_empty() {
+            return !self.prepared_statement.does_writes();
+        }
+        self.statement
+            .as_deref()
+            .map(is_retryable_query_statement)
+            .unwrap_or(false)
     }
 
     // used by ext_var_ref_iter
@@ -622,7 +691,7 @@ impl QueryRequest {
         let consumed_before = self.consumed_capacity;
         let mut opts = SendOptions {
             timeout: timeout,
-            retryable: true,
+            retryable: self.is_retryable(),
             compartment_id: self.compartment_id.clone(),
             table_name: self.rate_limit_table_name(),
             does_reads: true,
@@ -1035,5 +1104,49 @@ impl QueryRequest {
         }
         //println!(" set_result register {}: {:?}", reg, val);
         self.registers[reg as usize] = val;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_retryability_classifies_statement_text() {
+        assert!(QueryRequest::new("select * from users").is_retryable());
+        assert!(QueryRequest::new("  -- comment\n/* block */ SELECT * from users").is_retryable());
+        assert!(QueryRequest::new(
+            "declare $id integer; $name string; select * from users where id = $id"
+        )
+        .is_retryable());
+
+        assert!(!QueryRequest::new("insert into users(id) values(1)").is_retryable());
+        assert!(!QueryRequest::new("UPSERT into users(id) values(1)").is_retryable());
+        assert!(!QueryRequest::new("update users set name = 'a' where id = 1").is_retryable());
+        assert!(!QueryRequest::new("delete from users where id = 1").is_retryable());
+        assert!(!QueryRequest::new(
+            "declare $id integer; $name string; insert into users(id, name) values($id, $name)"
+        )
+        .is_retryable());
+        assert!(!QueryRequest::new("").is_retryable());
+    }
+
+    #[test]
+    fn prepare_only_queries_are_retryable_without_executing_mutation() {
+        assert!(QueryRequest::new("insert into users(id) values(1)")
+            .prepare_only()
+            .is_retryable());
+    }
+
+    #[test]
+    fn query_retryability_uses_prepared_operation_code() {
+        let mut prepared_select = PreparedStatement::default();
+        prepared_select.statement = vec![1];
+        prepared_select.operation = 5;
+        assert!(QueryRequest::new_prepared(&prepared_select).is_retryable());
+
+        let mut prepared_mutation = prepared_select.clone();
+        prepared_mutation.operation = 0;
+        assert!(!QueryRequest::new_prepared(&prepared_mutation).is_retryable());
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -146,6 +146,48 @@ impl Reader {
         packed_integer::read_packed_i64(&mut self.buf, &mut self.offset)
     }
 
+    pub(crate) fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.offset)
+    }
+
+    pub(crate) fn checked_count(&self, count: i32, context: &str) -> Result<usize, NoSQLError> {
+        Self::checked_count_with_limit(count, self.remaining(), context)
+    }
+
+    pub(crate) fn checked_count_with_limit(
+        count: i32,
+        max_count: usize,
+        context: &str,
+    ) -> Result<usize, NoSQLError> {
+        if count < 0 {
+            return Err(NoSQLError::new(
+                BadProtocolMessage,
+                format!("invalid negative count in {}", context).as_str(),
+            ));
+        }
+        let count = count as usize;
+        if count > max_count {
+            return Err(NoSQLError::new(
+                BadProtocolMessage,
+                format!("invalid count in {}", context).as_str(),
+            ));
+        }
+        Ok(count)
+    }
+
+    pub(crate) fn try_reserve_vec<T>(
+        values: &mut Vec<T>,
+        additional: usize,
+        context: &str,
+    ) -> Result<(), NoSQLError> {
+        values.try_reserve(additional).map_err(|_| {
+            NoSQLError::new(
+                BadProtocolMessage,
+                format!("unable to reserve decoded values for {}", context).as_str(),
+            )
+        })
+    }
+
     pub fn read_string(&mut self) -> Result<String, NoSQLError> {
         let slen = packed_integer::read_packed_i32(&mut self.buf, &mut self.offset)?;
         if slen <= 0 {
@@ -297,15 +339,11 @@ impl Reader {
         let _num_bytes = self.read_i32()?;
         // number of items in the array
         let num_items = self.read_i32()?;
-        if num_items < 0 || (num_items as usize) > self.buf.len() {
-            return Err(NoSQLError::new(
-                BadProtocolMessage,
-                "invalid num_items in array message",
-            ));
-        }
+        let num_items = self.checked_count(num_items, "array message")?;
         // walk items
         //println!("read_array: num_items={}", num_items);
-        let mut arr = Vec::<FieldValue>::with_capacity(num_items as usize);
+        let mut arr = Vec::<FieldValue>::new();
+        Self::try_reserve_vec(&mut arr, num_items, "array message")?;
         for _i in 0..num_items {
             let v = self.read_field_value()?;
             //println!(" array element {}: {:?}", i, v);
@@ -327,13 +365,9 @@ impl Reader {
             return Ok(Vec::new());
         }
         let ulen = len as usize;
-        if ulen > self.buf.len() {
-            return Err(NoSQLError::new(
-                BadProtocolMessage,
-                "invalid length in string array message",
-            ));
-        }
-        let mut arr: Vec<String> = Vec::with_capacity(ulen);
+        let ulen = Self::checked_count_with_limit(ulen as i32, self.remaining(), "string array")?;
+        let mut arr: Vec<String> = Vec::new();
+        Self::try_reserve_vec(&mut arr, ulen, "string array")?;
         for _i in 0..len {
             arr.push(self.read_string()?);
         }
@@ -352,14 +386,10 @@ impl Reader {
             return Ok(Vec::new());
         }
         let ulen = len as usize;
-        if ulen > self.buf.len() {
-            return Err(NoSQLError::new(
-                BadProtocolMessage,
-                "invalid length in i32 array message",
-            ));
-        }
+        let ulen = Self::checked_count_with_limit(ulen as i32, self.remaining(), "i32 array")?;
         //println!("read_i32_array: len={}", ulen);
-        let mut arr: Vec<i32> = Vec::with_capacity(ulen);
+        let mut arr: Vec<i32> = Vec::new();
+        Self::try_reserve_vec(&mut arr, ulen, "i32 array")?;
         for _i in 0..len {
             arr.push(self.read_packed_i32()?);
         }
@@ -371,6 +401,7 @@ impl Reader {
         let _num_bytes = self.read_i32()?;
         // number of items in the map
         let num_items = self.read_i32()?;
+        let num_items = self.checked_count(num_items, "map message")?;
         // walk items
         //println!("read_map: num_items={}", num_items);
         let mut mv = MapValue::new();

--- a/src/receive_iter.rs
+++ b/src/receive_iter.rs
@@ -685,8 +685,14 @@ impl ReceiveIter {
                 return ia_err!("expected more results than we got");
             }
 
-            let mut part_results: VecDeque<MapValue> =
-                VecDeque::with_capacity(num_results as usize);
+            let num_results = num_results as usize;
+            let mut part_results: VecDeque<MapValue> = VecDeque::new();
+            part_results.try_reserve(num_results).map_err(|_| {
+                NoSQLError::new(
+                    BadProtocolMessage,
+                    "unable to reserve decoded values for partition results",
+                )
+            })?;
             for _j in 0..num_results {
                 if let Some(r) = results.pop_front() {
                     part_results.push_back(r);

--- a/src/request_tests.rs
+++ b/src/request_tests.rs
@@ -4,10 +4,15 @@
 // Licensed under the Universal Permissive License v 1.0 as shown at
 //  https://oss.oracle.com/licenses/upl/
 //
+use crate::delete_request::*;
+use crate::get_indexes_request::*;
 use crate::get_request::*;
+use crate::list_tables_request::*;
 use crate::multi_delete_request::*;
 use crate::put_request::*;
 use crate::system_request::*;
+use crate::table_request::*;
+use crate::write_multiple_request::*;
 use crate::{nson::*, reader::Reader, types::*, writer::Writer};
 use std::error::Error;
 use std::time::Duration;
@@ -108,6 +113,33 @@ fn test_multi_delete_request_field_range() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn test_write_multiple_delete_subrequest_serializes_map() -> Result<(), Box<dyn Error>> {
+    let timeout = Duration::from_millis(30000);
+    let delete =
+        DeleteRequest::new("testusers", MapValue::new().i32("id", 42)).set_abort_on_fail(true);
+    let request = WriteMultipleRequest::new("testusers").add(Box::new(delete));
+    let mut w = Writer::new();
+    do_serialize(&request, &mut w, &timeout);
+
+    let mut reader = Reader::new().from_bytes(w.bytes());
+    let request = reader.read_field_value()?.get_map_value()?;
+    let payload = request.get_map(PAYLOAD).ok_or("payload missing")?;
+    assert_eq!(payload.get_i32(NUM_OPERATIONS), Some(1));
+
+    let operations = payload.get_array(OPERATIONS).ok_or("operations missing")?;
+    assert_eq!(operations.len(), 1);
+    let operation = operations[0].get_map_value_ref()?;
+
+    assert_eq!(operation.get_i32(OP_CODE), Some(OpCode::Delete as i32));
+    assert_eq!(operation.get_bool(ABORT_ON_FAIL), Some(true));
+    assert_eq!(operation.get_bool(RETURN_ROW), Some(true));
+    let key = operation.get_map(KEY).ok_or("key missing")?;
+    assert_eq!(key.get_i32("id"), Some(42));
+
+    Ok(())
+}
+
 fn serialized_op_code(r: &dyn NsonRequest, timeout: &Duration) -> Result<i32, Box<dyn Error>> {
     let mut w = Writer::new();
     do_serialize(r, &mut w, timeout);
@@ -116,6 +148,19 @@ fn serialized_op_code(r: &dyn NsonRequest, timeout: &Duration) -> Result<i32, Bo
     let request = reader.read_field_value()?.get_map_value()?;
     let header = request.get_map(HEADER).ok_or("header missing")?;
     header.get_i32(OP_CODE).ok_or("op code missing".into())
+}
+
+fn serialized_payload_namespace(
+    r: &dyn NsonRequest,
+    timeout: &Duration,
+) -> Result<Option<String>, Box<dyn Error>> {
+    let mut w = Writer::new();
+    do_serialize(r, &mut w, timeout);
+
+    let mut reader = Reader::new().from_bytes(w.bytes());
+    let request = reader.read_field_value()?.get_map_value()?;
+    let payload = request.get_map(PAYLOAD).ok_or("payload missing")?;
+    Ok(payload.get_string(NAMESPACE))
 }
 
 #[test]
@@ -132,6 +177,73 @@ fn test_system_request_op_codes() -> Result<(), Box<dyn Error>> {
 
     let status_request = SystemStatusRequest::new("operation-1");
     assert_eq!(serialized_op_code(&status_request, &timeout)?, 24);
+
+    Ok(())
+}
+
+#[test]
+fn test_table_metadata_requests_serialize_namespace() -> Result<(), Box<dyn Error>> {
+    let timeout = Duration::from_millis(30000);
+
+    let table_request = TableRequest::new("testusers")
+        .statement("create table testusers(id integer, primary key(id))")
+        .namespace("testns");
+    assert_eq!(
+        serialized_payload_namespace(&table_request, &timeout)?,
+        Some("testns".to_string())
+    );
+
+    let get_table_request = GetTableRequest::new("testusers")
+        .operation_id("operation-1")
+        .namespace("testns");
+    assert_eq!(
+        serialized_payload_namespace(&get_table_request, &timeout)?,
+        Some("testns".to_string())
+    );
+
+    let list_tables_request = ListTablesRequest::new().namespace("testns");
+    assert_eq!(
+        serialized_payload_namespace(&list_tables_request, &timeout)?,
+        Some("testns".to_string())
+    );
+
+    let get_indexes_request = GetIndexesRequest::new("testusers").namespace("testns");
+    assert_eq!(
+        serialized_payload_namespace(&get_indexes_request, &timeout)?,
+        Some("testns".to_string())
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_table_metadata_requests_omit_empty_namespace() -> Result<(), Box<dyn Error>> {
+    let timeout = Duration::from_millis(30000);
+
+    let table_request = TableRequest::new("testusers")
+        .statement("create table testusers(id integer, primary key(id))");
+    assert_eq!(
+        serialized_payload_namespace(&table_request, &timeout)?,
+        None
+    );
+
+    let get_table_request = GetTableRequest::new("testusers").operation_id("operation-1");
+    assert_eq!(
+        serialized_payload_namespace(&get_table_request, &timeout)?,
+        None
+    );
+
+    let list_tables_request = ListTablesRequest::new();
+    assert_eq!(
+        serialized_payload_namespace(&list_tables_request, &timeout)?,
+        None
+    );
+
+    let get_indexes_request = GetIndexesRequest::new("testusers");
+    assert_eq!(
+        serialized_payload_namespace(&get_indexes_request, &timeout)?,
+        None
+    );
 
     Ok(())
 }

--- a/src/request_tests.rs
+++ b/src/request_tests.rs
@@ -12,6 +12,7 @@ use crate::multi_delete_request::*;
 use crate::put_request::*;
 use crate::system_request::*;
 use crate::table_request::*;
+use crate::table_usage_request::*;
 use crate::write_multiple_request::*;
 use crate::{nson::*, reader::Reader, types::*, writer::Writer};
 use std::error::Error;
@@ -136,6 +137,25 @@ fn test_write_multiple_delete_subrequest_serializes_map() -> Result<(), Box<dyn 
     assert_eq!(operation.get_bool(RETURN_ROW), Some(true));
     let key = operation.get_map(KEY).ok_or("key missing")?;
     assert_eq!(key.get_i32("id"), Some(42));
+
+    Ok(())
+}
+
+#[test]
+fn test_table_usage_request_serializes_start_index() -> Result<(), Box<dyn Error>> {
+    let timeout = Duration::from_millis(30000);
+    let request = TableUsageRequest::new("testusers")
+        .limit(10)
+        .start_index(25);
+    let mut w = Writer::new();
+    do_serialize(&request, &mut w, &timeout);
+
+    let mut reader = Reader::new().from_bytes(w.bytes());
+    let request = reader.read_field_value()?.get_map_value()?;
+    let payload = request.get_map(PAYLOAD).ok_or("payload missing")?;
+
+    assert_eq!(payload.get_i32(LIST_MAX_TO_READ), Some(10));
+    assert_eq!(payload.get_i32(LIST_START_INDEX), Some(25));
 
     Ok(())
 }

--- a/src/rw_tests.rs
+++ b/src/rw_tests.rs
@@ -118,3 +118,27 @@ fn test_rw_with_offsets() -> Result<(), Box<dyn Error>> {
     assert_eq!(reader.read_packed_i32()?, 98765);
     Ok(())
 }
+
+#[test]
+fn test_truncated_packed_integers_return_errors() {
+    let mut reader = Reader::new().from_bytes(&[0xf8]);
+    assert!(reader.read_packed_i32().is_err());
+
+    let mut reader = Reader::new().from_bytes(&[0xf8]);
+    assert!(reader.read_packed_i64().is_err());
+
+    let mut reader = Reader::new().from_bytes(&[0x03, 0, 0, 0, 0, 0]);
+    assert!(reader.read_packed_i32().is_err());
+}
+
+#[test]
+fn test_malformed_collection_counts_return_errors() {
+    let mut reader = Reader::new().from_bytes(&[0, 0, 0, 0, 0, 0, 0, 1]);
+    assert!(reader.read_array().is_err());
+
+    let mut reader = Reader::new().from_bytes(&[0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff]);
+    assert!(reader.read_map().is_err());
+
+    let mut reader = Reader::new().from_bytes(&[0, 0, 0, 0, 0, 0, 0, 1]);
+    assert!(reader.read_map().is_err());
+}

--- a/src/rw_tests.rs
+++ b/src/rw_tests.rs
@@ -102,19 +102,19 @@ fn test_rw_with_offsets() -> Result<(), Box<dyn Error>> {
     let offset2 = writer.size();
     writer.write_i32(0);
     writer.write_packed_i32(98765);
-    writer.write_i32_at_offset(6543, offset1)?;
-    writer.write_i32_at_offset(1111, offset2)?;
+    writer.write_i32_at_offset(0x1234567, offset1)?;
+    writer.write_i32_at_offset(0x7f000001, offset2)?;
 
     let mut reader = Reader::new().from_bytes(writer.bytes());
     assert_eq!(reader.read_i32()?, 1234567);
     assert_eq!(reader.read_i16()?, 120);
     assert_eq!(reader.read_packed_i32()?, 545454);
-    assert_eq!(reader.read_i32()?, 6543);
+    assert_eq!(reader.read_i32()?, 0x1234567);
     assert_eq!(reader.read_packed_i64()?, 98765432198765);
     assert_eq!(reader.read_i32()?, 1);
     assert_eq!(reader.read_i16()?, 200);
     assert_eq!(reader.read_packed_i32()?, 222222);
-    assert_eq!(reader.read_i32()?, 1111);
+    assert_eq!(reader.read_i32()?, 0x7f000001);
     assert_eq!(reader.read_packed_i32()?, 98765);
     Ok(())
 }

--- a/src/sort_iter.rs
+++ b/src/sort_iter.rs
@@ -42,10 +42,15 @@ impl SortSpec {
     }
     pub fn read_sort_specs(r: &mut Reader) -> Result<Vec<SortSpec>, NoSQLError> {
         let num = r.read_packed_i32()?;
-        if num <= 0 {
+        if num < 0 {
+            return ia_err!("invalid sort spec count: {}", num);
+        }
+        if num == 0 {
             return Ok(Vec::new());
         }
-        let mut v: Vec<SortSpec> = Vec::with_capacity(num as usize);
+        let num = r.checked_count(num, "sort specs")?;
+        let mut v: Vec<SortSpec> = Vec::new();
+        Reader::try_reserve_vec(&mut v, num, "sort specs")?;
         for _i in 0..num {
             v.push(SortSpec::from_reader(r)?);
         }

--- a/src/sort_iter.rs
+++ b/src/sort_iter.rs
@@ -42,10 +42,7 @@ impl SortSpec {
     }
     pub fn read_sort_specs(r: &mut Reader) -> Result<Vec<SortSpec>, NoSQLError> {
         let num = r.read_packed_i32()?;
-        if num < 0 {
-            return ia_err!("invalid sort spec count: {}", num);
-        }
-        if num == 0 {
+        if num <= 0 {
             return Ok(Vec::new());
         }
         let num = r.checked_count(num, "sort specs")?;

--- a/src/table_request.rs
+++ b/src/table_request.rs
@@ -172,6 +172,7 @@ impl TableRequest {
             timeout: timeout,
             retryable: false,
             compartment_id: self.compartment_id.clone(),
+            namespace: self.namespace.clone(),
             ..Default::default()
         };
         let mut r = h.send_and_receive(w, &mut opts).await?;
@@ -199,9 +200,9 @@ impl TableRequest {
         if let Some(etag) = &self.match_etag {
             ns.write_string_field(ETAG, etag);
         }
+        ns.write_nonempty_string_field(NAMESPACE, &self.namespace);
         // TODO: these are currently only in http headers. Add to NSON?
         //ns.write_string_field(COMPARTMENT_OCID, &self.compartment_id);
-        //ns.write_string_field(NAMESPACE, &self.namespace);
         ns.end_payload();
 
         ns.end_request();
@@ -350,9 +351,9 @@ impl GetTableRequest {
         if !self.operation_id.is_empty() {
             ns.write_string_field(OPERATION_ID, &self.operation_id);
         }
+        ns.write_nonempty_string_field(NAMESPACE, &self.namespace);
         // TODO: these are currently only in http headers. Add to NSON?
         //ns.write_string_field(COMPARTMENT_OCID, &self.compartment_id);
-        //ns.write_string_field(NAMESPACE, &self.namespace);
         ns.end_payload();
 
         ns.end_request();

--- a/src/table_usage_request.rs
+++ b/src/table_usage_request.rs
@@ -5,7 +5,6 @@
 //  https://oss.oracle.com/licenses/upl/
 //
 use crate::error::NoSQLError;
-use crate::error::NoSQLErrorCode::BadProtocolMessage;
 use crate::handle::Handle;
 use crate::handle::SendOptions;
 use crate::nson::*;
@@ -176,7 +175,7 @@ impl TableUsageRequest {
             ns.write_string_field(END, &s);
         }
         ns.write_nonzero_i32_field(LIST_MAX_TO_READ, self.limit);
-        ns.write_nonzero_i32_field(LIST_MAX_TO_READ, self.start_index);
+        ns.write_nonzero_i32_field(LIST_START_INDEX, self.start_index);
         ns.end_payload();
 
         ns.end_request();
@@ -203,14 +202,10 @@ impl TableUsageRequest {
                     MapWalker::expect_type(walker.r, FieldType::Array)?;
                     let _ = walker.r.read_i32()?; // skip array size in bytes
                     let num_elements = walker.r.read_i32()?;
-                    if num_elements < 0 || (num_elements as usize) > walker.r.buf.len() {
-                        return Err(NoSQLError::new(
-                            BadProtocolMessage,
-                            "invalid num_elements in usage array",
-                        ));
-                    }
-                    res.usage_records = Vec::with_capacity(num_elements as usize);
-                    for _n in 1..=num_elements {
+                    let num_elements = walker.r.checked_count(num_elements, "usage array")?;
+                    res.usage_records = Vec::new();
+                    Reader::try_reserve_vec(&mut res.usage_records, num_elements, "usage array")?;
+                    for _n in 0..num_elements {
                         res.usage_records
                             .push(TableUsageRequest::read_usage_record(walker.r)?);
                     }

--- a/src/write_multiple_request.rs
+++ b/src/write_multiple_request.rs
@@ -6,7 +6,6 @@
 //
 use crate::delete_request::DeleteRequest;
 use crate::error::NoSQLError;
-use crate::error::NoSQLErrorCode::BadProtocolMessage;
 use crate::error::NoSQLErrorCode::IllegalArgument;
 use crate::handle::Handle;
 use crate::handle::SendOptions;
@@ -300,14 +299,10 @@ impl WriteMultipleRequest {
                     MapWalker::expect_type(walker.r, FieldType::Array)?;
                     let _ = walker.r.read_i32()?; // skip array size in bytes
                     let num_elements = walker.r.read_i32()?;
-                    if num_elements < 0 || (num_elements as usize) > walker.r.buf.len() {
-                        return Err(NoSQLError::new(
-                            BadProtocolMessage,
-                            "invalid num_elements in results array",
-                        ));
-                    }
-                    res.results = Vec::with_capacity(num_elements as usize);
-                    for _n in 1..=num_elements {
+                    let num_elements = walker.r.checked_count(num_elements, "results array")?;
+                    res.results = Vec::new();
+                    Reader::try_reserve_vec(&mut res.results, num_elements, "results array")?;
+                    for _n in 0..num_elements {
                         res.results
                             .push(WriteMultipleRequest::read_result(walker.r)?);
                     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -76,10 +76,7 @@ impl Writer {
                 offset
             );
         }
-        let arr = val.to_be_bytes();
-        for i in 1..4 {
-            self.buf[offset + i] = arr[i];
-        }
+        self.buf[offset..offset + 4].copy_from_slice(&val.to_be_bytes());
         Ok(())
     }
 


### PR DESCRIPTION
- Internal auth/SIU retry can replay non-idempotent bodies
- Namespace setters are dropped for table DDL and get-indexes
- Delete subrequests in write-multiple are not finalized as NSON maps
- Table usage start index is serialized under the limit field name
- Instance-principal refresh bypasses the handle client used for initial credential acquisition
- Instance-principal tenancy parsing can truncate the default compartment id
- Resource-principal token expiration is parsed but not enforced or refreshed
- Instance and resource principals default missing compartment to tenancy/root
- NSON map and array length backpatching omits the high byte
- Response decoders can panic or allocate from malformed packed integers and unchecked counts