### PR TITLE
Preparing for 0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 0.1.4 06/22/2026
+
+### Changed
+- Now requires Rust version 1.88 or higher
+
+### Added
+- Support for UNION operator
+- Internal rate limiting
+- Support for a few edge-case query types that did not make it into previous releases
+
+### Fixed
+
+- Several fixes for issues found from AI scanning:
+    - Debug/trace logging can expose credentials, auth headers, tokens
+    - Multi-delete field ranges can become unbounded deletes
+    - System request op codes are shifted by a missing DropIndex slot
+    - Advanced-query internal fetches drop per-request compartment and limits
+    - Internal auth/SIU retry can replay non-idempotent bodies
+    - Namespace setters are dropped for table DDL and get-indexes
+    - Delete subrequests in write-multiple are not finalized as NSON maps
+    - NSON map and array length backpatching omits the high byte
+    - Instance-principal refresh bypasses the handle client used for initial credential acquisition
+    - Table usage start index is serialized under the limit field name
+    - Response decoders can panic or allocate from malformed packed integers and unchecked counts
+    - Instance-principal tenancy parsing can truncate the default compartment id
+    - Resource-principal token expiration is parsed but not enforced or refreshed
+    - Instance and resource principals default missing compartment to tenancy/root
+
 ## 0.1.3 05/18/2026
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oracle-nosql-rust-sdk"
-version = "0.1.3"
-rust-version = "1.78"
+version = "0.1.4"
+rust-version = "1.88"
 license = "UPL-1.0"
 description = "Oracle Rust SDK for the NoSQL Database"
 keywords = ["nosql", "oracle", "database"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 
 ### Prerequisites
-- Rust 1.78 or later
+- Rust 1.88 or later
   - Download and install a [Rust](https://www.rust-lang.org/tools/install) binary release suitable for your system. See the install and setup instructions on that page.
 - Oracle NoSQL Database. Use one of the options:
   - Subscribe to the [Oracle NoSQL Database Cloud Service](https://www.oracle.com/database/nosql-cloud.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //!
 //! ## Prerequisites
-//! - Rust 1.78 or later
+//! - Rust 1.88 or later
 //!   - Download and install a [Rust](https://www.rust-lang.org/tools/install) binary release suitable for your system. See the install and setup instructions on that page.
 //! - Oracle NoSQL Database. Use one of the options:
 //!   - Subscribe to the [Oracle NoSQL Database Cloud Service](https://www.oracle.com/database/nosql-cloud.html).


### PR DESCRIPTION
## 0.1.4 06/22/2026

### Changed
- Now requires Rust version 1.88 or higher

### Added
- Support for UNION operator
- Internal rate limiting
- Support for a few edge-case query types that did not make it into previous releases

### Fixed

- Several fixes for issues found from AI scanning:
    - Debug/trace logging can expose credentials, auth headers, tokens
    - Multi-delete field ranges can become unbounded deletes
    - System request op codes are shifted by a missing DropIndex slot
    - Advanced-query internal fetches drop per-request compartment and limits
    - Internal auth/SIU retry can replay non-idempotent bodies
    - Namespace setters are dropped for table DDL and get-indexes
    - Delete subrequests in write-multiple are not finalized as NSON maps
    - NSON map and array length backpatching omits the high byte
    - Instance-principal refresh bypasses the handle client used for initial credential acquisition
    - Table usage start index is serialized under the limit field name
    - Response decoders can panic or allocate from malformed packed integers and unchecked counts
    - Instance-principal tenancy parsing can truncate the default compartment id
    - Resource-principal token expiration is parsed but not enforced or refreshed
    - Instance and resource principals default missing compartment to tenancy/root